### PR TITLE
Add Game filter to '/search mods'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/pg": "^7.14.4",
     "@types/request-promise-native": "^1.0.17",
     "bluebird": "^3.7.2",
+    "closest-match": "^1.3.3",
     "discord-api-types": "^0.26.1",
     "discord.js": "^13.6.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
~~I couldn't get the bot to actually respond with an API search, but that's a problem with trying to set up a local copy of the bot for testing—not with the code itself.~~ Ended up fudging the responses the bot would get from the container, and it works!

The game filter is fuzzy and will give a game within about a third of a perfect match, calculated using the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm (via a new NPM package). If no game is found within that parameter, a new message will be shown to the user.

The user's game input is also printed to the log for debugging ease.