### PR TITLE
Always ensure a user's roles are accurate on /link

### DIFF
--- a/src/interactions/link.ts
+++ b/src/interactions/link.ts
@@ -44,6 +44,10 @@ async function action(client: Client, baseInteraction: CommandInteraction): Prom
             const guild = client.guilds.cache.get(interaction.guildId)
             await addServerLink(client, userData, interaction.user, guild as Guild).catch(() => undefined);
             await interaction.followUp({ content:`Your Discord account has been linked to ${userData.name} in this server.`,  ephemeral: true });
+
+            // If the user is already linked, make sure their roles are correct.
+            if (client.user) await updateAllRoles(client, userData, client.user, true);
+
             return;
         }
         else {


### PR DESCRIPTION
Thanks to some fun shenanigans I engaged in with one of your moderators, I got some firsthand experience on what happens when a user is kicked from a server they were previously linked in. To regain one's roles, one must use `/unlink global:false` and then `/link` again.

This PR addresses that by having `/link` ensure that a user's roles are up-to-date, even if they were already linked in that server.

While I'm not technically sure if this will work (since I was never able to get the Docker container running), I do believe it should™.