### PR TITLE
Automod False Positive Reduction

### DIFF
--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -366,7 +366,7 @@ async function analyseURLS(text: string, logger: Logger): Promise<string[]> {
         try {
             const finalUrl = await tall(url, { timeout: 5 });
             if (finalUrl) {
-                if (finalUrl !== url) {
+                if (finalUrl.replace(/\/$/, "") !== url.replace(/\/$/, "")) {
                     logger.info("Expanded URL", { url, finalUrl })
                     result.push(`${url} => ${finalUrl}`)
                 }

--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -390,8 +390,10 @@ async function analyseURLS(text: string, logger: Logger): Promise<string[]> {
 }
 
 function filterUrls(uri: string): boolean {
-    if (uri.toLowerCase().includes('nexusmods.com')) return false;
-    const ext = uri.split('.').pop()?.toLowerCase()
+    uri = uri.toLowerCase();
+    if (uri.includes('nexusmods.com')) return false;
+    if (uri.startsWith("https://aka.ms/")) return false;
+    const ext = uri.split('.').pop()
 
     const imageExts = ["jpg", "jpeg", "png", "gif", "bmp", 
     "tiff", "tif", "webp", "svg", "ico", "heic"];

--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -393,6 +393,7 @@ function filterUrls(uri: string): boolean {
     uri = uri.toLowerCase();
     if (uri.includes('nexusmods.com')) return false;
     if (uri.startsWith("https://aka.ms/")) return false;
+    if (uri.startsWith("https://github.com/") && uri.endsWith("/latest")) return false;
     const ext = uri.split('.').pop()
 
     const imageExts = ["jpg", "jpeg", "png", "gif", "bmp", 

--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -373,10 +373,10 @@ async function analyseURLS(text: string, logger: Logger): Promise<string[]> {
         try {
             const finalUrl = await tall(url, { timeout: 5 });
             if (finalUrl) {
-                if (finalUrl.replace(/\/$/, "") !== url.replace(/\/$/, "")) {
-                    logger.info("Expanded URL", { url, finalUrl })
-                    result.push(`${url} => ${finalUrl}`)
-                }
+                if (finalUrl.replace(/\/$/, "") === url.replace(/\/$/, "")) continue;
+
+                logger.info("Expanded URL", { url, finalUrl })
+                result.push(`${url} => ${finalUrl}`)
             }
             // else logMessage('Could not expand url', url)
 

--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -344,7 +344,14 @@ async function analyseMod(mod: IModForAutomod, rules: IAutomodRule[], badFiles: 
         allText = `${allText}\n\n${urls.map(u => u.toLowerCase()).join('\n')}`;
     }
     rules.forEach(rule => {
-        if (allText.includes(rule.filter.toLowerCase())) {
+        let filter = rule.filter.toLowerCase();
+        if (filter.startsWith("regex:")) {
+            const regEx = new RegExp(filter.slice(6))
+            if (regEx.test(allText)) {
+                flags[rule.type].push(rule.reason)
+            }
+        }
+        else if (allText.includes(filter)) {
             flags[rule.type].push(rule.reason)
         }
     });

--- a/src/feeds/AutoModManager.ts
+++ b/src/feeds/AutoModManager.ts
@@ -375,6 +375,15 @@ async function analyseURLS(text: string, logger: Logger): Promise<string[]> {
             if (finalUrl) {
                 if (finalUrl.replace(/\/$/, "") === url.replace(/\/$/, "")) continue;
 
+                const protocols = ["http", "https"];
+                let parts = url.split(":", 1);
+                let finalParts = finalUrl.split(":", 1);
+                if (parts[0] !== finalParts[0] && parts[1] === finalParts[1]) {
+                    // Initial and final URL are the same, except for an HTTPS redirect
+                    if (protocols.includes(parts[0]) && protocols.includes(finalParts[0])) continue;
+                }
+                if (finalUrl.split(":") === url.replace(/\/$/, "")) continue;
+
                 logger.info("Expanded URL", { url, finalUrl })
                 result.push(`${url} => ${finalUrl}`)
             }


### PR DESCRIPTION
To reduce the number of Automod false positives, I've made these changes:

- Ignore trailing slash when comparing URLs:
  - https://&zwnj;www.python.org/downloads => https://&zwnj;www.python.org/downloads/ 
- Ignore http <=> https redirects where the URL is otherwise identical:
  - **http**://&zwnj;www.python.org/downloads/ => **https**://&zwnj;www.python.org/downloads/ 
- Ignore aka.ms redirects:
  - https://&zwnj;aka.ms/vs/17/release/vc_redist.x64.exe => https://&zwnj;download.visualstudio.microsoft.com/[...]/VC_redist.x64.exe
- Ignore GitHub /latest redirects:
  - https://&zwnj;github.com/Nexus-Mods/Vortex/releases/latest => https://&zwnj;github.com/Nexus-Mods/Vortex/releases/tag/v1.14.8
- Allow regex in rules by prefixing the filter with `regex:`
  This would allow replacing `Optimizer` with `regex:(?<!Cathedral Assets? )Optimizer`