### PR TITLE
memory fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-bot-typescript",
   "type": "module",
-  "version": "3.16.2",
+  "version": "3.16.3",
   "description": "A Discord bot for Nexus Mods, written in TypeScript",
   "main": "dist/app.js",
   "scripts": {

--- a/src/DiscordBot.ts
+++ b/src/DiscordBot.ts
@@ -1,4 +1,4 @@
-import { REST, Client, Collection, GatewayIntentBits, Routes, Snowflake, IntentsBitField, RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
+import { REST, Client, Collection, GatewayIntentBits, Routes, Snowflake, IntentsBitField, RESTPostAPIApplicationCommandsJSONBody, Options } from 'discord.js';
 import * as fs from 'fs';
 import path from 'path';
 import { isTesting, Logger } from './api/util';
@@ -25,7 +25,16 @@ export class DiscordBot {
 
     private token: Snowflake = process.env.DISCORD_TOKEN as Snowflake;
     private clientId: Snowflake = process.env.DISCORD_CLIENT_ID as Snowflake;
-    public client: ClientExt = new Client({ intents });
+    public client: ClientExt = new Client({
+        intents,
+        // discord.js doesn't evict cached users or members by default, so they pile up until the bot has to be restarted. Sweep them on a timer.
+        sweepers: {
+            ...Options.DefaultSweeperSettings,
+            messages: { interval: 3600, lifetime: 1800 },
+            users: { interval: 3600, filter: () => (user) => user.id !== user.client.user?.id },
+            guildMembers: { interval: 3600, filter: () => (member) => member.id !== member.client.user?.id },
+        },
+    });
     public logger: Logger = logger;
     private rest: REST = new REST({ version: '10' }).setToken(this.token);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -179,6 +179,8 @@ export class AuthSite {
             const userId = meData.user.id;
             // Store the Discord token temporarily
             this.TempStore.set(clientState, { id: userId, name: `${meData.user.username}#${meData.user.discriminator}`, tokens });
+            // If they don't come back to finish linking, drop the stored tokens after 5 mins so the store doesn't grow forever.
+            setTimeout(() => this.TempStore.delete(clientState), 1000 * 60 * 5);
 
             // Forward to Nexus Mods auth.
             const { url } = NexusModsOAuth.getOAuthUrl(clientState, this.logger);
@@ -211,6 +213,8 @@ export class AuthSite {
             res.sendStatus(403);
             return;
         }
+        // Read the data out, so drop the store entry.
+        this.TempStore.delete(clientState);
 
         try {
             const existingUser: DiscordBotUser|undefined = await getUserByDiscordId(discordData.id);


### PR DESCRIPTION
Fixes part of a slow memory leak, per pickysaurus necessitating a restart every few days.

- discord.js never sweeps its user and member caches by default, so with the
  GuildMessages intent they grew with every user the bot saw and were never
  freed. Added sweepers for messages, users and members.

- The account link flow kept Discord tokens in TempStore but never removed
  them, so the map only ever grew. It now drops each entry after use, with a
  5 minute fallback for link attempts that never finish.