### PR TITLE
fix(db): use query_timeout, not statement_timeout, so a pooler accept…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,12 @@ AUTOMOD_DATABASE=
 # safe setting; set DB_SSL_CA too if the server uses a private root.
 #DB_SSL=on
 #DB_SSL_CA=
-# Cancel any query still running after this many milliseconds. Without it one stuck
-# query holds a pool connection until the process restarts.
+# Give up on a query still running after this many milliseconds, freeing the pool
+# connection. 0 disables. This is a client-side timer (pg's query_timeout) rather than
+# the server's statement_timeout, because pg sends statement_timeout in the startup
+# packet and PgBouncer rejects it. It does not cancel the query on the server - to bound
+# that too, set it on the role, where no pooler or deploy can lose it:
+#     ALTER ROLE <user> SET statement_timeout = '15s';
 #DB_STATEMENT_TIMEOUT_MS=15000
 
 # Anti-spam bait channel. Leave unset unless the feature is wanted: setting it makes

--- a/src/api/dbConnect.ts
+++ b/src/api/dbConnect.ts
@@ -91,10 +91,9 @@ function buildPoolConfig(): PoolConfig {
         // ephemeral one and the connection failed somewhere far from the cause.
         port: envInt(process.env.DBPORT ?? process.env.PORT, 5432, 'DBPORT'),
         ssl: sslConfig(),
-        // A query that runs longer than this is cancelled by the server. Without it a
-        // single stuck query holds a pool connection until the process restarts, and ten
-        // of them deadlock the bot. This was written and then commented out.
-        statement_timeout: envInt(process.env.DB_STATEMENT_TIMEOUT_MS, 15000, 'DB_STATEMENT_TIMEOUT_MS'),
+        // query_timeout, not statement_timeout: see queryTimeoutMs below. The latter is a
+        // startup parameter and PgBouncer refuses it.
+        query_timeout: queryTimeoutMs(),
         connectionTimeoutMillis: 5000,
         // Was 2000, which closed connections after two seconds idle and made the bot
         // reconnect constantly between feed polls - TLS handshake and all.
@@ -117,6 +116,34 @@ let cachedConfig: PoolConfig | undefined;
 export function poolConfig(): PoolConfig {
     cachedConfig ??= buildPoolConfig();
     return cachedConfig;
+}
+
+/**
+ * How long a query may run before the client gives up. 0 disables.
+ *
+ * Without a limit, one stuck query holds a pool connection until the process restarts,
+ * and ten of them deadlock the bot. That is the problem being solved, and it is a
+ * *client-side* problem - so it wants a client-side fix.
+ *
+ * 4.0.0 set pg's `statement_timeout` pool option instead. pg sends that in the **startup
+ * packet**, and PgBouncer - which production connects through - rejects any startup
+ * parameter outside its allow-list: `unsupported startup parameter`, SQLSTATE 08P01,
+ * FATAL. Every connection was refused and the bot could not migrate.
+ *
+ * `query_timeout` is implemented by pg itself with a timer, sends nothing at connection
+ * time, and passes through a pooler unremarked. Verified against PgBouncer 1.22 in
+ * transaction mode: the query aborts and the pool stays usable.
+ *
+ * What it does **not** do is cancel the query on the server - that keeps running until it
+ * finishes. To bound server-side work as well, set it on the role, which no pooler can
+ * undo and no deploy can forget:
+ *
+ *     ALTER ROLE <user> SET statement_timeout = '15s';
+ */
+function queryTimeoutMs(): number {
+    const raw = process.env.DB_STATEMENT_TIMEOUT_MS;
+    if (raw !== undefined && raw.trim() === '0') return 0;
+    return envInt(raw, 15000, 'DB_STATEMENT_TIMEOUT_MS');
 }
 
 /** The pools this module can query. `main` is the bot's database; `automod` is the rules database. */
@@ -280,6 +307,22 @@ function handleDatabaseError(error: unknown): DatabaseError {
             userMessage,
             context: { code, detail },
         });
+    }
+
+    // 08P01 with this text is PgBouncer refusing a startup parameter it does not
+    // allow-list. It is a configuration problem, not a transient one, and the message
+    // should say which parameter and where to fix it.
+    if (err.message.includes('unsupported startup parameter')) {
+        return new DatabaseError(
+            `The database connection pooler rejected a startup parameter (${err.message}). `
+            + 'Connection options that pg sends in the startup packet do not survive PgBouncer; '
+            + 'set the value with SET after connecting, or on the role with ALTER ROLE.',
+            {
+                cause: err,
+                isOperational: false,
+                userMessage: 'The bot could not connect to the database. Please report this.',
+            },
+        );
     }
 
     if (err.message === 'The server does not support SSL connections') {

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -61,7 +61,9 @@ export async function runMigrations(): Promise<void> {
     const folder = migrationsFolder();
     // A dedicated pool, separate from the app's. max: 2 because one connection
     // holds the advisory lock for the whole run while the migrator uses another.
-    const pool = new Pool({ ...poolConfig(), max: 2, idleTimeoutMillis: 0 });
+    // query_timeout is deliberately cleared: the app wants stuck queries killed, but a
+    // migration can legitimately take minutes and must not be aborted half way.
+    const pool = new Pool({ ...poolConfig(), max: 2, idleTimeoutMillis: 0, query_timeout: undefined });
     let lockClient: pg.PoolClient | undefined;
 
     try {

--- a/tests/api/dbConnect.test.ts
+++ b/tests/api/dbConnect.test.ts
@@ -118,10 +118,41 @@ describe('ssl', () => {
     });
 });
 
-describe('other settings', () => {
-    it('sets a statement timeout, which used to be commented out', async () => {
-        expect((await loadConfig()).statement_timeout).toBe(15000);
+describe('query timeout', () => {
+    // The problem being solved is client-side: a stuck query holding a pool connection.
+    //
+    // 4.0.0 used pg's `statement_timeout` pool option, which pg sends in the **startup
+    // packet**. PgBouncer - which production connects through - rejects startup
+    // parameters outside its allow-list with a FATAL "unsupported startup parameter"
+    // (SQLSTATE 08P01), so every connection was refused and the bot could not start.
+    // `query_timeout` is a pg-side timer, sends nothing at connection time, and passes
+    // through a pooler. Verified against PgBouncer 1.22 in transaction mode.
+    it('uses query_timeout, not statement_timeout', async () => {
+        const cfg = await loadConfig();
+        expect(cfg.query_timeout).toBe(15000);
+        expect(cfg.statement_timeout).toBeUndefined();
     });
+
+    it('never sets a startup parameter that a pooler would refuse', async () => {
+        const cfg = await loadConfig() as Record<string, unknown>;
+        // pg forwards these to the server at connection time.
+        for (const key of ['statement_timeout', 'idle_in_transaction_session_timeout', 'options', 'application_name']) {
+            expect(cfg[key]).toBeUndefined();
+        }
+    });
+
+    it('can be disabled with 0, for a database that sets it on the role instead', async () => {
+        process.env.DB_STATEMENT_TIMEOUT_MS = '0';
+        expect((await loadConfig()).query_timeout).toBe(0);
+    });
+
+    it('is configurable', async () => {
+        process.env.DB_STATEMENT_TIMEOUT_MS = '4000';
+        expect((await loadConfig()).query_timeout).toBe(4000);
+    });
+});
+
+describe('other settings', () => {
 
     it('no longer drops idle connections after two seconds', async () => {
         expect((await loadConfig()).idleTimeoutMillis).toBe(30000);


### PR DESCRIPTION
…s it

Second regression from the 3.2 pool-config change, and it took production down on the 4.0.0 deploy. Every connection was refused with:

    unsupported startup parameter: statement_timeout   (08P01, FATAL)

pg sends a `statement_timeout` pool option in the **startup packet**. PgBouncer - which production connects through, as a DigitalOcean managed connection pool - rejects any startup parameter outside its allow-list. The bot could not migrate, so it refused to start, correctly and repeatedly.

The problem the setting was added for is client-side: a stuck query holding a pool connection until the process restarts. So it wants a client-side fix. `query_timeout` is a timer inside pg, sends nothing at connection time, aborts the query and leaves the pool usable. Verified against PgBouncer 1.22 in transaction mode: the old option reproduces the exact production error, the new one connects, and a slow query aborts on schedule with the pool still working afterwards.

What query_timeout does not do is cancel the query on the server. To bound that as well, the place to set it is the role, where no pooler can undo it and no deploy can forget it:

    ALTER ROLE <user> SET statement_timeout = '15s';

That is now in .env.example next to the setting.

Migrations are exempted - `query_timeout: undefined` on the migration pool. A migration can legitimately run for minutes and must not be aborted half way. The baseline is fast, but the next one might not be.

08P01 now maps to a message naming the parameter and saying where to set it instead, rather than a generic database error.

Verified end to end with the real built dist against PgBouncer, on both paths that matter: a fresh database migrates to a schema identical to the production dump, and a database already carrying the production schema is left untouched with the baseline recorded as applied.

Tests assert query_timeout is set, statement_timeout is not, and that no other pg option which travels in the startup packet is set either - which is the general form of this mistake.


Claude-Session: https://claude.ai/code/session_014UgnybAmouFdpyC2LuugUL