### PR TITLE
Replaced server-side stored state

### DIFF
--- a/src/server/linkState.ts
+++ b/src/server/linkState.ts
@@ -1,0 +1,111 @@
+import crypto from 'node:crypto';
+
+/**
+ * The in-flight state of an account link, sealed into a cookie.
+ *
+ * The link flow spans two OAuth round trips: Discord hands back tokens, then the user
+ * goes off to Nexus Mods and comes back, and only then is there enough to write a row.
+ * The Discord tokens have to survive that gap. They used to survive it in a Map on the
+ * AuthSite instance, which made the web service single-replica by construction and
+ * meant every deploy dropped anyone mid-link into a 403 - the tokens went with the
+ * process.
+ *
+ * The fix is not to move the state somewhere more durable. It is to stop the server
+ * holding it. A table would have put live Discord access and refresh tokens in a second
+ * place on disk in plaintext, which is the thing Phase 3.4 exists to stop; sealing them
+ * into a cookie the browser carries through the redirect chain leaves the server with no
+ * state at all, so replica count and restarts stop mattering rather than mattering less.
+ *
+ * The trade, stated plainly: the tokens spend up to five minutes on the user's own
+ * device instead of in the server's memory. They are that user's own tokens, they are
+ * encrypted with a key the client does not have, the cookie is httpOnly so page scripts
+ * cannot read it, and they are about to be stored server-side anyway.
+ *
+ * The ciphertext format is deliberately versioned - `v1.iv.tag.ciphertext` - because
+ * Phase 3.4 needs the same shape for the tokens in the users table, and a five-minute
+ * value is a much better place to get rotation and rejection behaviour right than
+ * 147,000 rows where losing the key costs every linked user a re-link.
+ */
+export interface LinkState {
+    /** The OAuth state this payload belongs to. Checked on open, so one flow's cookie cannot finish another. */
+    state: string;
+    /** Discord user id. */
+    id: string;
+    /** Display name, used for the success page and the log line. */
+    name: string;
+    tokens: {
+        access_token: string;
+        refresh_token: string;
+        expires_at: number;
+        token_type?: string;
+        scope?: string;
+    };
+}
+
+interface SealedPayload extends LinkState {
+    /** Absolute expiry, enforced on open. The cookie's maxAge is a client-side courtesy. */
+    exp: number;
+}
+
+export const LINK_STATE_COOKIE = 'linkState';
+export const LINK_STATE_TTL_MS = 5 * 60 * 1000;
+
+const VERSION = 'v1';
+
+/**
+ * A secret is not a key. HKDF turns the cookie secret into 32 bytes suitable for
+ * AES-256, and the info string scopes it - the same secret used elsewhere derives a
+ * different key, so this cookie cannot be swapped for another use of the same value.
+ */
+function keyFor(secret: string): Buffer {
+    return Buffer.from(crypto.hkdfSync('sha256', Buffer.from(secret, 'utf8'), Buffer.alloc(0), Buffer.from('link-state.v1'), 32));
+}
+
+export function sealLinkState(payload: LinkState, secret: string, ttlMs: number = LINK_STATE_TTL_MS): string {
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', keyFor(secret), iv);
+    const body: SealedPayload = { ...payload, exp: Date.now() + ttlMs };
+    const ciphertext = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(body), 'utf8')), cipher.final()]);
+    return [VERSION, iv.toString('base64url'), cipher.getAuthTag().toString('base64url'), ciphertext.toString('base64url')].join('.');
+}
+
+/**
+ * Returns null for every failure - tampered, expired, wrong secret, wrong state,
+ * malformed, absent. The caller cannot act differently on any of them, and a function
+ * that throws four different ways here invites a catch block that treats a forged
+ * cookie as a transient error.
+ *
+ * `expectedState` binds the payload to the OAuth state on the request. Without it a
+ * cookie captured from one link attempt would complete a different one.
+ */
+export function openLinkState(sealed: unknown, secret: string, expectedState: string): LinkState | null {
+    if (typeof sealed !== 'string') return null;
+    const [version, iv, tag, ciphertext] = sealed.split('.');
+    if (version !== VERSION || !iv || !tag || !ciphertext) return null;
+
+    let parsed: SealedPayload;
+    try {
+        const decipher = crypto.createDecipheriv('aes-256-gcm', keyFor(secret), Buffer.from(iv, 'base64url'));
+        decipher.setAuthTag(Buffer.from(tag, 'base64url'));
+        const plain = Buffer.concat([decipher.update(Buffer.from(ciphertext, 'base64url')), decipher.final()]);
+        parsed = JSON.parse(plain.toString('utf8')) as SealedPayload;
+    }
+    catch {
+        // A bad auth tag, a wrong key and malformed base64 all land here. GCM verifies
+        // the tag in final(), so tampering cannot get past this point.
+        return null;
+    }
+
+    if (typeof parsed?.exp !== 'number' || Date.now() > parsed.exp) return null;
+    if (typeof parsed.state !== 'string' || !safeEqual(parsed.state, expectedState)) return null;
+    if (typeof parsed.id !== 'string' || typeof parsed.tokens?.access_token !== 'string') return null;
+
+    return { state: parsed.state, id: parsed.id, name: parsed.name, tokens: parsed.tokens };
+}
+
+function safeEqual(a: string, b: string): boolean {
+    const ab = Buffer.from(a, 'utf8');
+    const bb = Buffer.from(b, 'utf8');
+    if (ab.length !== bb.length) return false;
+    return crypto.timingSafeEqual(ab, bb);
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,6 +18,7 @@ import { automodRules } from './AutomodRules.js';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { checkSharedSecret, cookieOptions, OPTIONAL_SECRETS, REQUIRED_SECRETS, safeCompare, verifyValue } from './auth.js';
+import { LINK_STATE_COOKIE, LINK_STATE_TTL_MS, openLinkState, sealLinkState } from './linkState.js';
 
 // Get the equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -31,10 +32,10 @@ const __dirname = path.dirname(__filename);
  * its own process (`dist/web.js`) and holds no Discord state: what it needed from the
  * client is a DiscordDirectory, which is two REST calls.
  *
- * TempStore is still an in-memory Map, which makes this single-replica by construction.
- * A second replica would answer the Nexus callback for a link the other replica started
- * and reject it as unknown state. Moving it to the database or Redis is what a second
- * replica needs; nothing else here does.
+ * It holds no state between requests. The in-flight half of an account link - the
+ * Discord tokens, waiting for the user to come back from Nexus Mods - used to live in a
+ * Map on this instance, which made the service single-replica and meant a deploy dropped
+ * anyone mid-link into a 403. It is sealed into a cookie now; see linkState.ts.
  */
 export class AuthSite {
     private static instance: AuthSite;
@@ -43,7 +44,6 @@ export class AuthSite {
     private logger: Logger;
     private port = process.env.AUTH_PORT || 3000;
     private server?: Server;
-    public TempStore: Map<string, { name: string, id: string, tokens: any }> = new Map();
 
     private constructor(directory: DiscordDirectory, logger: Logger) {
         this.directory = directory;
@@ -222,10 +222,14 @@ export class AuthSite {
 
             const meData = await DiscordOAuth.getUserData(tokens);
             const userId = meData.user.id;
-            // Store the Discord token temporarily
-            this.TempStore.set(clientState, { id: userId, name: `${meData.user.username}#${meData.user.discriminator}`, tokens });
-            // If they don't come back to finish linking, drop the stored tokens after 5 mins so the store doesn't grow forever.
-            setTimeout(() => this.TempStore.delete(clientState), 1000 * 60 * 5);
+            // Hand the half-finished link back to the browser, sealed. The five-minute
+            // expiry is inside the sealed payload as well as on the cookie, so an
+            // abandoned link cannot be resumed by replaying the cookie later.
+            const sealed = sealLinkState(
+                { state: clientState, id: userId, name: `${meData.user.username}#${meData.user.discriminator}`, tokens },
+                process.env.COOKIE_SECRET!,
+            );
+            res.cookie(LINK_STATE_COOKIE, sealed, cookieOptions(LINK_STATE_TTL_MS));
 
             // Forward to Nexus Mods auth.
             const { url } = NexusModsOAuth.getOAuthUrl(clientState, this.logger);
@@ -251,15 +255,22 @@ export class AuthSite {
             return;
         }
 
-        // Get the Discord data from the store
-        const discordData = this.TempStore.get(clientState);
+        // Unseal the Discord half of the link. openLinkState returns null for every
+        // failure - forged, expired, wrong secret, or belonging to a different flow -
+        // because none of them is recoverable and telling them apart here would only
+        // invite treating a forged cookie as a transient error.
+        // signedCookies, not cookies: cookieOptions sets signed: true, so cookie-parser
+        // puts it there (and puts `false` there if the signature fails, which
+        // openLinkState rejects along with everything else non-string).
+        const discordData = openLinkState(req.signedCookies?.[LINK_STATE_COOKIE], process.env.COOKIE_SECRET!, clientState);
+        // Read once: clear it whether or not it opened, so a failed attempt does not
+        // leave tokens sitting in the browser for the rest of the window.
+        res.clearCookie(LINK_STATE_COOKIE);
         if (!discordData) {
             this.logger.warn('Could not find matching Discord Auth to pair accounts', req.url);
             res.sendStatus(403);
             return;
         }
-        // Read the data out, so drop the store entry.
-        this.TempStore.delete(clientState);
 
         try {
             const existingUser: DiscordBotUser|undefined = await getUserByDiscordId(discordData.id);

--- a/tests/server/link-flow.test.ts
+++ b/tests/server/link-flow.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import crypto from 'node:crypto';
+
+/**
+ * The account link, driven end to end through a real listening server with a cookie jar.
+ *
+ * The unit tests cover the sealing. This covers the wiring, which is where the mistakes
+ * actually happen: the first version of this change read the cookie from `req.cookies`
+ * instead of `req.signedCookies`, which type-checks, passes every unit test, and 403s
+ * every real link. Only a test that drives the flow catches that.
+ */
+const DISCORD_TOKENS = { access_token: 'D'.repeat(30), refresh_token: 'DR'.repeat(15), expires_at: 1_900_000_000_000 };
+const NEXUS_TOKENS = { access_token: 'N'.repeat(30), refresh_token: 'NR'.repeat(15), expires_at: 1_900_000_000_000 };
+let created: Record<string, unknown> | null = null;
+
+// The rate limiter is switched off here, and finding that out was worth the detour.
+// `sensitiveLimit` is one limiter instance shared by /linked-role, both OAuth callbacks,
+// /revoke and the two metadata endpoints - express-rate-limit counts per key per
+// instance, not per route - so a single IP gets 10 requests a minute across all of them,
+// and one completed link spends three. These tests exhaust it in the third case.
+vi.mock('express-rate-limit', () => ({
+    default: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../src/server/DiscordOAuth.js', () => ({
+    getOAuthUrl: () => { const state = crypto.randomBytes(16).toString('base64url'); return { url: `https://discord.test/authorize?state=${state}`, state }; },
+    getOAuthTokens: async () => DISCORD_TOKENS,
+    getUserData: async () => ({ user: { id: '4242', username: 'mike', discriminator: '0' } }),
+    revoke: async () => undefined,
+}));
+
+vi.mock('../../src/server/NexusModsOAuth.js', () => ({
+    getOAuthUrl: (state: string) => ({ url: `https://nexus.test/authorize?state=${state}` }),
+    getOAuthTokens: async () => NEXUS_TOKENS,
+    getUserData: async () => ({ sub: '31179975', name: 'Pickysaurus', avatar: '', membership_roles: ['premium'] }),
+    revoke: async () => undefined,
+}));
+
+vi.mock('../../src/api/users.js', () => ({
+    getUserByDiscordId: async () => undefined,
+    getUserByNexusModsId: async () => undefined,
+    deleteUser: async () => undefined,
+    updateUser: async () => ({}),
+    createUser: async (u: Record<string, unknown>) => {
+        created = u;
+        return { DiscordId: u.d_id, NexusModsUsername: u.name,
+            Discord: { PushMetaData: async () => undefined, GetRemoteMetaData: async () => ({}) },
+            NexusMods: { Auth: async () => undefined, Refresh: async () => undefined } };
+    },
+}));
+
+const PORT = 31556;
+const BASE = `http://127.0.0.1:${PORT}`;
+let site: { close(): Promise<void> };
+
+beforeAll(async () => {
+    process.env.COOKIE_SECRET = 'integration-cookie-secret-0123456789';
+    process.env.UNLINK_SECRET = 'integration-unlink-secret';
+    process.env.AUTH_PORT = String(PORT);
+    process.env.NODE_ENV = 'testing';
+    const { AuthSite } = await import('../../src/server/server.js');
+    const noop = () => undefined;
+    const logger = { info: noop, warn: noop, error: noop, debug: noop } as any;
+    site = AuthSite.getInstance({ guild: async () => null, channels: async () => [] } as any, logger);
+    await new Promise((r) => setTimeout(r, 250));
+});
+afterAll(async () => { await site?.close(); });
+
+/** A browser: keeps cookies, honours Set-Cookie deletions, does not follow redirects. */
+function browser() {
+    const jar = new Map<string, string>();
+    return {
+        jar,
+        async go(path: string) {
+            const res = await fetch(BASE + path, {
+                redirect: 'manual',
+                headers: jar.size ? { cookie: [...jar].map(([k, v]) => `${k}=${v}`).join('; ') } : {},
+            });
+            for (const c of res.headers.getSetCookie()) {
+                const [pair] = c.split(';');
+                const i = pair.indexOf('=');
+                const name = pair.slice(0, i);
+                const value = pair.slice(i + 1);
+                if (value === '') jar.delete(name); else jar.set(name, value);
+            }
+            return res;
+        },
+    };
+}
+
+async function startLink(b: ReturnType<typeof browser>) {
+    const res = await b.go('/linked-role');
+    const location = res.headers.get('location');
+    if (!location) throw new Error(`/linked-role returned ${res.status}, remaining=${res.headers.get('ratelimit-remaining')}`);
+    return new URL(location).searchParams.get('state')!;
+}
+
+describe('the account link survives having no server-side state', () => {
+    it('completes, and writes both token sets', async () => {
+        created = null;
+        const b = browser();
+        const state = await startLink(b);
+        expect(b.jar.has('clientState')).toBe(true);
+
+        const discord = await b.go(`/discord-oauth-callback?code=abc&state=${encodeURIComponent(state)}`);
+        expect(discord.status).toBe(302);
+        expect(discord.headers.get('location')).toContain('nexus.test');
+        const sealed = b.jar.get('linkState');
+        expect(sealed).toBeTruthy();
+
+        // The property the whole design rests on: the browser is holding the Discord
+        // tokens, and cannot read them.
+        expect(decodeURIComponent(sealed!)).not.toContain(DISCORD_TOKENS.access_token);
+        expect(decodeURIComponent(sealed!)).not.toContain(DISCORD_TOKENS.refresh_token);
+
+        const nexus = await b.go(`/nexus-mods-callback?code=xyz&state=${encodeURIComponent(state)}`);
+        expect(nexus.status).toBe(302);
+        expect(nexus.headers.get('location')).toContain('/success');
+        expect(created).toMatchObject({
+            d_id: '4242',
+            discord_access: DISCORD_TOKENS.access_token,
+            nexus_access: NEXUS_TOKENS.access_token,
+        });
+
+        // Read once: the cookie is cleared on the way out.
+        expect(b.jar.has('linkState')).toBe(false);
+    });
+
+    it('rejects the Nexus callback when the Discord half never happened', async () => {
+        created = null;
+        const b = browser();
+        const state = await startLink(b);
+        const res = await b.go(`/nexus-mods-callback?code=xyz&state=${encodeURIComponent(state)}`);
+        expect(res.status).toBe(403);
+        expect(created).toBeNull();
+    });
+
+    // The state binding, exercised through the wire rather than the unit.
+    it('rejects a linkState cookie captured from a different link attempt', async () => {
+        created = null;
+        const victim = browser();
+        const victimState = await startLink(victim);
+        await victim.go(`/discord-oauth-callback?code=abc&state=${encodeURIComponent(victimState)}`);
+        const stolen = victim.jar.get('linkState')!;
+
+        const attacker = browser();
+        const attackerState = await startLink(attacker);
+        attacker.jar.set('linkState', stolen);
+        const res = await attacker.go(`/nexus-mods-callback?code=xyz&state=${encodeURIComponent(attackerState)}`);
+        expect(res.status).toBe(403);
+        expect(created).toBeNull();
+    });
+
+    it('rejects a forged linkState cookie', async () => {
+        created = null;
+        const b = browser();
+        const state = await startLink(b);
+        b.jar.set('linkState', 'v1.AAAA.BBBB.CCCC');
+        const res = await b.go(`/nexus-mods-callback?code=xyz&state=${encodeURIComponent(state)}`);
+        expect(res.status).toBe(403);
+        expect(created).toBeNull();
+    });
+
+    // What the old Map could not do: a second process, or the same one after a restart,
+    // finishes a link it never started.
+    it('is completed by a server that has no memory of starting it', async () => {
+        created = null;
+        const b = browser();
+        const state = await startLink(b);
+        await b.go(`/discord-oauth-callback?code=abc&state=${encodeURIComponent(state)}`);
+
+        // Nothing is carried over between requests, so a restart is indistinguishable
+        // from any other request as far as the flow is concerned.
+        const res = await b.go(`/nexus-mods-callback?code=xyz&state=${encodeURIComponent(state)}`);
+        expect(res.status).toBe(302);
+        expect(created).not.toBeNull();
+    });
+});

--- a/tests/server/linkState.test.ts
+++ b/tests/server/linkState.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LINK_STATE_TTL_MS, openLinkState, sealLinkState, type LinkState } from '../../src/server/linkState.js';
+
+const SECRET = 'a-cookie-secret-of-a-realistic-length-0123456789';
+const STATE = 'nS8xQ2p0YkR2VzloTmpZeA';
+
+const payload: LinkState = {
+    state: STATE,
+    id: '215154001799413770',
+    name: 'Pickysaurus#0',
+    tokens: {
+        access_token: 'a'.repeat(30),
+        refresh_token: 'r'.repeat(30),
+        expires_at: 1_800_000_000_000,
+        token_type: 'Bearer',
+        scope: 'role_connections.write identify',
+    },
+};
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('sealing', () => {
+    it('round-trips the payload the Nexus callback needs', () => {
+        const opened = openLinkState(sealLinkState(payload, SECRET), SECRET, STATE);
+        expect(opened).toEqual(payload);
+    });
+
+    it('produces a different ciphertext each time, so the cookie is not a stable fingerprint', () => {
+        expect(sealLinkState(payload, SECRET)).not.toBe(sealLinkState(payload, SECRET));
+    });
+
+    // The reason this fits in a cookie at all. Browsers cap a cookie at about 4 KB.
+    it('stays well inside the cookie size limit, even with oversized tokens', () => {
+        expect(sealLinkState(payload, SECRET).length).toBeLessThan(1024);
+        const big = { ...payload, tokens: { ...payload.tokens, access_token: 'a'.repeat(255), refresh_token: 'r'.repeat(255) } };
+        expect(sealLinkState(big, SECRET).length).toBeLessThan(2048);
+    });
+
+    it('does not leak the tokens into the cookie in readable form', () => {
+        const sealed = sealLinkState(payload, SECRET);
+        expect(sealed).not.toContain(payload.tokens.access_token);
+        expect(sealed).not.toContain(payload.tokens.refresh_token);
+        expect(sealed).not.toContain(payload.id);
+    });
+});
+
+describe('rejection', () => {
+    const cases: [string, () => unknown][] = [
+        ['a tampered ciphertext', () => sealLinkState(payload, SECRET).slice(0, -4) + 'AAAA'],
+        ['a tampered auth tag', () => { const p = sealLinkState(payload, SECRET).split('.'); p[2] = Buffer.from('0'.repeat(16)).toString('base64url'); return p.join('.'); }],
+        ['a value sealed with a different secret', () => sealLinkState(payload, 'some-other-secret-entirely')],
+        ['an unknown format version', () => 'v2' + sealLinkState(payload, SECRET).slice(2)],
+        ['a malformed value', () => 'not-a-sealed-cookie'],
+        ['an empty string', () => ''],
+        ['a missing cookie', () => undefined],
+        ['cookie-parser\'s signature-failure value', () => false],
+    ];
+    it.each(cases)('rejects %s', (_label, make) => {
+        expect(openLinkState(make(), SECRET, STATE)).toBeNull();
+    });
+
+    // Without this, a cookie captured from one link attempt could complete another.
+    it('rejects a payload sealed for a different OAuth state', () => {
+        const sealed = sealLinkState(payload, SECRET);
+        expect(openLinkState(sealed, SECRET, 'a-completely-different-state')).toBeNull();
+    });
+
+    it('rejects when the state inside was altered to match a different flow', () => {
+        const sealed = sealLinkState({ ...payload, state: 'attacker-chosen-state' }, SECRET);
+        expect(openLinkState(sealed, SECRET, STATE)).toBeNull();
+    });
+});
+
+describe('expiry', () => {
+    // The cookie's maxAge is a client-side courtesy; nothing stops a client sending an
+    // expired cookie forever. The expiry that matters is the one inside the payload.
+    it('rejects a payload past its expiry even though the cookie was replayed intact', () => {
+        vi.useFakeTimers();
+        const sealed = sealLinkState(payload, SECRET);
+        expect(openLinkState(sealed, SECRET, STATE)).not.toBeNull();
+        vi.advanceTimersByTime(LINK_STATE_TTL_MS + 1000);
+        expect(openLinkState(sealed, SECRET, STATE)).toBeNull();
+    });
+
+    it('still opens just inside the window', () => {
+        vi.useFakeTimers();
+        const sealed = sealLinkState(payload, SECRET);
+        vi.advanceTimersByTime(LINK_STATE_TTL_MS - 1000);
+        expect(openLinkState(sealed, SECRET, STATE)).not.toBeNull();
+    });
+});


### PR DESCRIPTION
When authenticating, the Discord tokens are sealing, encrypted and stored in the user's browser.